### PR TITLE
* 兼容 icqq/onebots 后端

### DIFF
--- a/nonebot_plugin_multincm/__main__.py
+++ b/nonebot_plugin_multincm/__main__.py
@@ -213,6 +213,7 @@ async def send_music(song: SongInfo):
             "title": format_alias(song.name, song.alia) if is_song else song.name,
             "content": format_artists(song.ar) if is_song else song.radio.name,
             "image": song.al.picUrl if is_song else song.coverUrl,
+            "jumpUrl": f"https://music.163.com/{'song' if is_song else 'dj'}?id={song_id}"
         },
     )
 


### PR DESCRIPTION
没有传`id`的情况下，`icqq/onebots`无法解析出` jumpUrl`, 因此自定义参数时需要主动传递此字段